### PR TITLE
make `require`-able

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
 	  "type": "git",
 	  "url": "https://github.com/RactiveJS/plugins.adaptors.Backbone.git"
 	},
+	"dependencies": {
+		"backbone": "~1.1.0",
+		"ractive": "~0.3.7"
+	},
 	"devDependencies": {
 		"grunt": "~0.4.1",
 		"grunt-contrib-concat": "~0.3.0",


### PR DESCRIPTION
allows for `require('ractive-backbone')` using browserify
