### PR TITLE
Update for Backbone model for deep keypath

### DIFF
--- a/src/Ractive-Backbone.js
+++ b/src/Ractive-Backbone.js
@@ -111,10 +111,21 @@
 			return this.value.attributes;
 		},
 		set: function ( keypath, value ) {
-			// Only set if the model didn't originate the change itself, and
-			// only if it's an immediate child property
-			if ( !this.setting && keypath.indexOf( '.' ) === -1 ) {
-				this.value.set( keypath, value );	
+			// Only set if the model didn't originate the change itself
+			if ( !this.setting ) {
+				var parts = keypath.split('.');
+				var target = {};
+				var last = target;
+				for (var i in parts) {
+					var part = parts[i];
+					if (i == (parts.length - 1)) {
+						last[part] = value;
+					} else {
+						last[part] = {};
+					}
+					last = last[part];
+				}
+				this.value.set( target );
 			}
 		},
 		reset: function ( object ) {


### PR DESCRIPTION
As I asked in https://github.com/RactiveJS/Ractive-adaptors-Backbone/issues/4, I don't really understand why Backbone models are only updated for immediate child property changes. I'd love to use deep models here.

This pull request fixes this behavior, but maybe there is a good reason for it. If so, I would happy to know why we should only propagate changes for immediate child property changes.