### PR TITLE
Add support of component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,20 @@
+{
+  "name": "ractive-adaptors-backbone",
+  "repository": "ractivejs/ractive-adaptors-backbone",
+  "description": "Backbone adaptor for Ractive.js",
+  "version": "0.1.1",
+  "keywords": [
+    "backbone",
+    "ractive",
+    "data binding",
+    "templates"
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "ractivejs/ractive": "*"
+  },
+  "main": "ractive-adaptors-backbone.js",
+  "scripts": [
+    "ractive-adaptors-backbone.js"
+  ]
+}


### PR DESCRIPTION
Here is a manifest file.
Keep it in the master branch and in releases tag, as described here: https://github.com/ractivejs/ractive/issues/1181

I've added `ractive` dependency, but haven't add `Backbone` to allow users decide between original `Backbone` and `exoskeleton`.
`component` users should know this simple trick:

``` JS
require.define("backbone", require("exoskeleton"));
```

Also there is some issue with `component` itself, it can't handle your js-style and requires explicit aliasing for all dependencies. Here is the PR about it: https://github.com/visionmedia/node-requires/pull/9
